### PR TITLE
make sure events don't crash when an entity is not found

### DIFF
--- a/homeassistant/components/niko_home_control/fan.py
+++ b/homeassistant/components/niko_home_control/fan.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
         entity = None
         action_type = action.action_type
         if action_type == 3:
-            NikoHomeControlFan(action, hub, options=entry.data["options"])
+            entity = NikoHomeControlFan(action, hub, options=entry.data["options"])
 
         if entity:
             hub.entities.append(entity)
@@ -44,11 +44,13 @@ class NikoHomeControlFan(FanEntity):
         self._attr_name = action.name
         self._attr_is_on = action.is_on
         self._attr_unique_id = f"fan-{action.action_id}"
-        self._fan_speed = action.state
+        self._attr_speed_count = 3
+        self._enable_turn_on_off_backwards_compatibility = False
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+            FanEntityFeature.SET_SPEED
         )
-        self._preset_modes = ["low", "medium", "high", "very_high"]
+        self._percentages = [33, 66, 100]
+        self._attr_percentage = self._percentages[action.state]
 
         if options["treatAsDevice"] is not False:
             self._attr_device_info = {
@@ -56,10 +58,10 @@ class NikoHomeControlFan(FanEntity):
                 "manufacturer": "Niko",
                 "name": action.name,
                 "model": "P.O.M",
+                "suggested_area": action.location,
                 "via_device": hub._via_device,
             }
-            if options["importLocations"] is not False:
-                self._attr_device_info["suggested_area"] = action.location
+
         else:
             self._attr_device_info = hub._device_info
 
@@ -74,43 +76,31 @@ class NikoHomeControlFan(FanEntity):
         return self._action.action_id
 
     @property
-    def preset_mode(self) -> str:
-        """Return the current preset mode."""
-        return self._fan_speed
-
-    @property
     def supported_features(self):
         """Return supported features."""
         return self._attr_supported_features
 
     def set_percentage(self, percentage: int) -> None:
         """Set the fan speed preset based on a given percentage."""
-        mode = percentage_to_ordered_list_item(self._preset_modes, percentage)
-        if mode == "low":
-            self._action.set_fan_speed(0)
-        elif mode == "medium":
-            self._action.set_fan_speed(1)
-        elif mode == "high":
-            self._action.set_fan_speed(2)
-        elif mode == "very_high":
-            self._action.set_fan_speed(3)
+        mode = 0 # low
+        if percentage > 67:
+            mode = 2 # high
+        elif percentage <= 67 and percentage > 33:
+            mode = 1 # medium
 
-        self.schedule_update_ha_state()
-
-    def set_preset_mode(self, preset_mode: str) -> None:
-        """Set the preset mode of the fan."""
-        if preset_mode == "low":
-            self._action.set_fan_speed(0)
-        elif preset_mode == "medium":
-            self._action.set_fan_speed(1)
-        elif preset_mode == "high":
-            self._action.set_fan_speed(2)
-        elif preset_mode == "very_high":
-            self._action.set_fan_speed(3)
-
+        self._attr_percentage = self._percentages[mode]
+        self._action.set_fan_speed(mode)
         self.schedule_update_ha_state()
 
     def update_state(self, state):
         """Update HA state."""
-        self._fan_speed = state
-        self.schedule_update_ha_state()
+        if state > 2: # map "boost" to high state
+            state = 2
+
+        self._attr_percentage = self._percentages[state]
+        self.async_write_ha_state()
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed of the fan, as a percentage."""
+        """Implemeted here as we do not want to call turn_off() when percentage == 0"""
+        await self.hass.async_add_executor_job(self.set_percentage, percentage)

--- a/homeassistant/components/niko_home_control/fan.py
+++ b/homeassistant/components/niko_home_control/fan.py
@@ -47,10 +47,11 @@ class NikoHomeControlFan(FanEntity):
         self._attr_speed_count = 3
         self._enable_turn_on_off_backwards_compatibility = False
         self._attr_supported_features = (
-            FanEntityFeature.SET_SPEED
+            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
         )
         self._percentages = [33, 66, 100]
         self._attr_percentage = self._percentages[action.state]
+        self._attr_preset_modes = ["Boost"]
 
         area = None
         if options["importLocations"] is not False:
@@ -78,11 +79,6 @@ class NikoHomeControlFan(FanEntity):
         """A Niko Action action_id."""
         return self._action.action_id
 
-    @property
-    def supported_features(self):
-        """Return supported features."""
-        return self._attr_supported_features
-
     def set_percentage(self, percentage: int) -> None:
         """Set the fan speed preset based on a given percentage."""
         mode = 0 # low
@@ -92,15 +88,26 @@ class NikoHomeControlFan(FanEntity):
             mode = 1 # medium
 
         self._attr_percentage = self._percentages[mode]
+        self._attr_preset_mode = None
         self._action.set_fan_speed(mode)
         self.schedule_update_ha_state()
 
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode of the fan."""
+        if preset_mode == "Boost":
+            self._action.set_fan_speed(3)
+            self._attr_preset_mode = "Boost"
+            self._attr_percentage = None
+
     def update_state(self, state):
         """Update HA state."""
-        if state > 2: # map "boost" to high state
-            state = 2
+        if state == 3: # boost state
+            self._attr_preset_mode = "Boost"
+            self._attr_percentage = None
+        else:
+            self._attr_preset_mode = None
+            self._attr_percentage = self._percentages[state]
 
-        self._attr_percentage = self._percentages[state]
         self.async_write_ha_state()
 
     async def async_set_percentage(self, percentage: int) -> None:

--- a/homeassistant/components/niko_home_control/hub.py
+++ b/homeassistant/components/niko_home_control/hub.py
@@ -145,7 +145,8 @@ class Hub:
                     if "event" in message and message["event"] == "listactions":
                         for _action in message["data"]:
                             entity = self.get_entity(_action["id"])
-                            entity.update_state(_action["value1"])
+                            if entity is not None:
+                                entity.update_state(_action["value1"])
             except any:
                 _LOGGER.debug("exception")
                 _LOGGER.debug(line)
@@ -153,4 +154,7 @@ class Hub:
     def get_entity(self, action_id):
         """Get entity by id."""
         actions = [action for action in self.entities if action.id == action_id]
-        return actions[0]
+        try:
+            return actions[0]
+        except IndexError:
+            return None


### PR DESCRIPTION
Fix bug that crashes the integration when an event is received for an entity that is disabled in HA